### PR TITLE
update: template to support all Kibana configuration parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ None.
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see `defaults/main.yml`):
+All Kibana configuration parameters are supported. This is achieved using a configuration map parameter `kibana_conf` which is serialized into the ${kibana}.yml file. The use of a map ensures the Ansible playbook does not need to be updated to reflect new/deprecated/plugin configuration parameters.
+
+    kibana_conf: ""
+
+In addition to the kibana_conf map, several other parameters are supported for basic functions. These can be found below.
 
     kibana_version: "7.x"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+kibana_conf: ""
+
 kibana_version: "7.x"
 
 kibana_package: kibana

--- a/templates/kibana.yml.j2
+++ b/templates/kibana.yml.j2
@@ -121,3 +121,5 @@ elasticsearch.password: "{{ kibana_elasticsearch_password }}"
 # The default locale. This locale can be used in certain circumstances to substitute any missing
 # translations.
 #i18n.defaultLocale: "en"
+
+{{ kibana_conf | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
The goal is to add a `kibana_conf` as a map, in order to support any Kibana configuration parameters.